### PR TITLE
[FRONTEND] Update Srinidhi's image and profile URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Meet our wonderful team comprised of Product Managers, Designers, Tech Leads, En
                 </a>
             </td>
             <td align="center" width="150">
-                <a href="https://umd.hack4impact.org/">
-                <img src="frontend/src/assets/winrock-profile-pictures/pending-image.jpg" height="100" width="100" style="border-radius:50%;object-fit:cover;"/><br/>
+                <a href="https://www.linkedin.com/in/srinidhi-gubba">
+                <img src="frontend/src/assets/winrock-profile-pictures/srinidhi-gubba-headshot.jpg" height="100" width="100" style="border-radius:50%;object-fit:cover;"/><br/>
                 <b>Srinidhi Gubba</b><br/><br/>
                 <img src="https://img.shields.io/badge/💻_engineer-27AE60?style=flat-square"/>
                 </a>


### PR DESCRIPTION
Task: Update the readme with profile url and image of self
Files Changed: edits in the .README file and new file added to the frontend/src/assets/winrock-profile-pictures folder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the team member profile for Srinidhi Gubba: replaced the placeholder avatar with a headshot and updated the link to point directly to the correct LinkedIn profile.
  - Users will now see the accurate photo and can navigate to the correct LinkedIn page from the documentation/about section.
  - No other profiles, content, or layout were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->