### PR TITLE
[FRONTEND] Added client column to project dashboard page

### DIFF
--- a/frontend/src/dashboards/project-view/updatesProjects.tsx
+++ b/frontend/src/dashboards/project-view/updatesProjects.tsx
@@ -1,6 +1,7 @@
 interface Project {
     id: string;
     project: string;
+    clientName: string;
     supplierName: string;
     overallStatus: 'On Track' | 'At Risk' | 'Paused' | 'Completed' | 'Completed (except for risk)';
     analysisStage: 'Risk & Co-benefit Assessment' | 'GHG Assessment Analysis' | 'Confirming Final Requirements' | 'Clarifying Initial Project Information' | 'Complete, and Excluded' | 'Clarifying Technical Details';
@@ -16,6 +17,7 @@ interface Project {
     {
       id: "Project1",
       project: 'Nestlé',
+      clientName: 'Philipp Navratil',
       supplierName: 'Cargill',
       overallStatus: 'On Track',
       analysisStage: 'Clarifying Technical Details',
@@ -29,6 +31,7 @@ interface Project {
     {
       id: "Project2",
       project: 'McCormick',
+      clientName: 'Brendan Foley',
       supplierName: 'Orange',
       overallStatus: 'At Risk',
       analysisStage: 'Clarifying Initial Project Information',
@@ -42,6 +45,7 @@ interface Project {
     {
         id: "Pixel",
         project: 'Pixel',
+        clientName: 'Sundar Pichai',
         supplierName: 'Alphabet',
         overallStatus: 'At Risk',
         analysisStage: 'GHG Assessment Analysis',
@@ -55,6 +59,7 @@ interface Project {
     {
         id: "Microsoft",
         project: 'Copilot',
+        clientName: 'Mustafa Suleyman',
         supplierName: 'Microsoft',
         overallStatus: 'Completed',
         analysisStage: 'GHG Assessment Analysis',
@@ -68,6 +73,7 @@ interface Project {
     {
         id: "CloudForce",
         project: 'Cloudforce',
+        clientName: 'Husein Sharaf',
         supplierName: 'Microsoft',
         overallStatus: 'On Track',
         analysisStage: 'GHG Assessment Analysis',
@@ -81,6 +87,7 @@ interface Project {
     {
         id: "Nike",
         project: 'Air Force 1',
+        clientName: 'Elliott Hill',
         supplierName: 'Nike',
         overallStatus: 'Completed',
         analysisStage: 'Confirming Final Requirements',
@@ -94,6 +101,7 @@ interface Project {
     {
       id: "Project3",
       project: 'Microsoft',
+      clientName: 'Satya Nadella',
       supplierName: 'Kiwi',
       overallStatus: 'Paused',
       analysisStage: 'Confirming Final Requirements',
@@ -107,6 +115,7 @@ interface Project {
     {
       id: "Project4",
       project: 'WebMD',
+      clientName: 'Robert Brisco',
       supplierName: 'Apple',
       overallStatus: 'Completed',
       analysisStage: 'Clarifying Initial Project Information',
@@ -120,6 +129,7 @@ interface Project {
     {
       id: "Project5",
       project: 'Kellogg',
+      clientName: 'Gary Pilnick',
       supplierName: 'Grape',
       overallStatus: 'Completed (except for risk)',
       analysisStage: 'Complete, and Excluded',
@@ -133,6 +143,7 @@ interface Project {
     {
       id: "Project6",
       project: 'Lululemon',
+      clientName: 'Calvin McDonald',
       supplierName: 'Orange',
       overallStatus: 'On Track',
       analysisStage: 'Clarifying Initial Project Information',
@@ -146,6 +157,7 @@ interface Project {
     {
       id: "Project7",
       project: 'Cheetos',
+      clientName: 'Richard Montañez',
       supplierName: 'Orange',
       overallStatus: 'On Track',
       analysisStage: 'Risk & Co-benefit Assessment',
@@ -159,6 +171,7 @@ interface Project {
     {
       id: "Project8",
       project: 'Cheezits',
+      clientName: 'Steve Cahillane',
       supplierName: 'Orange',
       overallStatus: 'Paused',
       analysisStage: 'Confirming Final Requirements',
@@ -172,6 +185,7 @@ interface Project {
     {
       id: "Project9",
       project: 'Cheerios',
+      clientName: 'Jeff Harmening',
       supplierName: 'Orange',
       overallStatus: 'Paused',
       analysisStage: 'Clarifying Initial Project Information',
@@ -185,6 +199,7 @@ interface Project {
     {
       id: "Project10",
       project: 'McCormick',
+      clientName: 'Brendan Foley',
       supplierName: 'Orange',
       overallStatus: 'Paused',
       analysisStage: 'Risk & Co-benefit Assessment',
@@ -198,6 +213,7 @@ interface Project {
     {
       id: "Project11",
       project: 'Tesla',
+      clientName: 'Elon Musk',
       supplierName: 'Lithium Corp',
       overallStatus: 'At Risk',
       analysisStage: 'GHG Assessment Analysis',
@@ -211,6 +227,7 @@ interface Project {
     {
       id: "Project12",
       project: 'Starbucks',
+      clientName: 'Brian Niccol',
       supplierName: 'Coffee Beans Co',
       overallStatus: 'On Track',
       analysisStage: 'Confirming Final Requirements',
@@ -224,6 +241,7 @@ interface Project {
     {
       id: "Project13",
       project: 'Nike',
+      clientName: 'Elliott Hill',
       supplierName: 'Cotton Express',
       overallStatus: 'Completed',
       analysisStage: 'Complete, and Excluded',
@@ -237,6 +255,7 @@ interface Project {
     {
       id: "Project14",
       project: 'Samsung',
+      clientName: 'Jun Young-hyun',
       supplierName: 'Green Energy Ltd',
       overallStatus: 'Completed (except for risk)',
       analysisStage: 'Risk & Co-benefit Assessment',
@@ -250,6 +269,7 @@ interface Project {
     {
       id: "Project15",
       project: 'Unilever',
+      clientName: 'Fernando Fernández',
       supplierName: 'Palm Oil Inc',
       overallStatus: 'At Risk',
       analysisStage: 'Clarifying Initial Project Information',

--- a/frontend/src/dashboards/winrock-dashboard/components/TableRow.tsx
+++ b/frontend/src/dashboards/winrock-dashboard/components/TableRow.tsx
@@ -23,6 +23,7 @@ interface TableRowProps {
   data: {
     id: string;
     project: string;
+    clientName: string;
     supplierName: string;
     overallStatus: StatusType;
     analysisStage: AnalysisStageType;
@@ -70,6 +71,7 @@ const TableRow: React.FC<TableRowProps> = ({
   onRowClick,
 }) => {
   // --- Local State for Editable Fields ---
+  const [localClientName, setLocalClientName] = useState(data.clientName);
   const [localSupplierName, setLocalSupplierName] = useState(data.supplierName);
   const [localOverallStatus, setLocalOverallStatus] = useState<StatusType>(data.overallStatus);
   const [localAnalysisStage, setLocalAnalysisStage] = useState<AnalysisStageType>(data.analysisStage);
@@ -80,6 +82,7 @@ const TableRow: React.FC<TableRowProps> = ({
 
   // Refresh local states when `data` changes
   useEffect(() => {
+    setLocalClientName(data.clientName);
     setLocalSupplierName(data.supplierName);
     setLocalOverallStatus(data.overallStatus);
     setLocalAnalysisStage(data.analysisStage);
@@ -124,6 +127,21 @@ const TableRow: React.FC<TableRowProps> = ({
       >
         {data.project}
       </td>
+      
+      {/* Client Name */}
+      <td className={styles.cell}>
+        {isEditMode ? (
+          <input
+            type="text"
+            value={localClientName}
+            onChange={(e) => setLocalClientName(e.target.value)}
+            className={styles.editableInput}
+          />
+        ) : (
+          data.clientName
+        )}
+      </td>
+
       {/* Supplier Name */}
       <td className={styles.cell}>
         {isEditMode ? (

--- a/frontend/src/dashboards/winrock-dashboard/css-modules/WinrockDashboard.module.css
+++ b/frontend/src/dashboards/winrock-dashboard/css-modules/WinrockDashboard.module.css
@@ -365,7 +365,7 @@ html {
 }
 
 .table {
-  width: 100%;
+  width: auto;
   border-collapse: collapse;
   table-layout: fixed;
 }

--- a/frontend/src/dashboards/winrock-dashboard/projects/winrockDashboard.tsx
+++ b/frontend/src/dashboards/winrock-dashboard/projects/winrockDashboard.tsx
@@ -23,6 +23,7 @@ import { db } from "../../../firebaseConfig.js";
 interface Project {
   id: string;
   project: string;
+  clientName: string;
   supplierName: string;
   overallStatus: 'On Track' | 'At Risk' | 'Paused' | 'Completed' | 'Completed (except for risk)';
   analysisStage: 'Risk & Co-benefit Assessment' | 'GHG Assessment Analysis' | 'Confirming Final Requirements' | 'Clarifying Initial Project Information' | 'Complete, and Excluded';
@@ -124,6 +125,7 @@ const WinrockDashboard: React.FC = () => {
         return {
           id: doc.id,
           project: typeof p.projectName === 'string' ? (p.projectName.charAt(0).toUpperCase() + p.projectName.slice(1)) : "Unknown Project",
+          clientName: typeof p.clientName === 'string' ? (p.clientName.split(' ').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join(' ')) : 'Unknown Client',
           supplierName: typeof p.supplierName === 'string' ? (p.supplierName.charAt(0).toUpperCase() + p.supplierName.slice(1)) : "Unknown Supplier",
           overallStatus: p.overallStatus,
           analysisStage: typeof p.analysisStage === 'string' && p.analysisStage.includes(':')
@@ -462,7 +464,7 @@ const WinrockDashboard: React.FC = () => {
             <TableHeader
               onSelectAll={handleSelectAll}
               allSelected={allSelected}
-              headers={['Project', 'Supplier', 'Overall Status', 'Analysis stage', 'Spend Category', 'Geography', 'Last Updated', 'Start Date', 'Action']}
+              headers={['Project', 'Client', 'Supplier', 'Overall Status', 'Analysis stage', 'Spend Category', 'Geography', 'Last Updated', 'Start Date', 'Action']}
               isEditMode={isEditMode}
             />
             <tbody>

--- a/frontend/src/dashboards/winrock-dashboard/projects/winrockDashboardService.ts
+++ b/frontend/src/dashboards/winrock-dashboard/projects/winrockDashboardService.ts
@@ -42,6 +42,7 @@ enum AnalysisStage {
  */
 interface Project {
     projectName: string;
+    clientName: string;
     supplierName: string;
     spendCategory: string;
     geography: string;
@@ -60,6 +61,7 @@ interface Project {
  * Saves a project with the given fields into the database.
  * 
  * @param {string} projectName - Must be unique across all projects.
+ * @param {string} clientName
  * @param {string} supplierName
  * @param {string} spendCategory
  * @param {string} geography
@@ -75,6 +77,7 @@ interface Project {
  */
 const createProject = async (
     projectName: string,
+    clientName: string,
     supplierName: string,
     spendCategory: string,
     geography: string,
@@ -94,6 +97,7 @@ const createProject = async (
         const now = Timestamp.now();
         const newProject: Project = {
             projectName,
+            clientName,
             supplierName,
             spendCategory,
             geography,


### PR DESCRIPTION
# Summary
- Updated files relating to winrockDashboard, TableRow, and updatesProjects.tsx
- Included a client column between "Project" and "Supplier" columns
- Updated sampleProjects (updatesProjects.tsx) to include clientName field
- Updated table to include editable cells for the client name
- Updated winrockDashboard.tsx to pull newly added data from Firebase for the clientName
- Updated width of table class to 'auto' (winrockDashboard.module.css) to stop table from overflowing off the screen
- Updated project-related interfaces appropriately  

<img width="1613" height="1087" alt="Screen Shot 2025-09-29 at 16 47 30" src="https://github.com/user-attachments/assets/fff9ba21-2a0e-4de0-b7bc-44bb6cd1d712" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a Client Name field to projects, shown as a new “Client” column in the Winrock dashboard.
  * Client Name is populated from data (defaults to “Unknown Client” if missing) and is editable in table rows.
  * Project creation now supports entering a Client Name.
* Style
  * Table width adjusted to auto for improved layout flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->