### PR TITLE
new date set to the future for filtering to work

### DIFF
--- a/frontend/src/dashboards/supplier-view/projects/supplierDashboard.tsx
+++ b/frontend/src/dashboards/supplier-view/projects/supplierDashboard.tsx
@@ -47,7 +47,7 @@ const SupplierDashboard: React.FC = () => {
   // These are used to control the date, i.e. save changes to the date filter calendar
   const [dateRange, setDateRange] = useState<DateRange>({
     startDate: null,
-    endDate: new Date()
+    endDate: new Date('2099-12-31') //TEMP CHANGE
   });
 
   const handleActionClick = (id: string | null) => {

--- a/frontend/src/dashboards/winrock-dashboard/projects/winrockDashboard.tsx
+++ b/frontend/src/dashboards/winrock-dashboard/projects/winrockDashboard.tsx
@@ -56,7 +56,7 @@ const WinrockDashboard: React.FC = () => {
   // These are used to control the date, i.e. save changes to the date filter calendar
   const [dateRange, setDateRange] = useState<DateRange>({
     startDate: null,
-    endDate: new Date('2099-12-31') //changed this to be a date in the future (would not show else)
+    endDate: new Date('2099-12-31') //TEMP CHANGE
   });
 
   const handleActionClick = (id: string | null) => {


### PR DESCRIPTION
two line change 
- winrock dashboard tsx (comment added saying temp change)
- supplier dashboard tsx (added in the updated new date and temp change comment)

https://github.com/Hack4Impact-UMD/winrock-international/issues/97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the default date range filter in the supplier dashboard to display data through a wider date window by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->