### PR TITLE
Hiding files when notes are open

### DIFF
--- a/frontend/src/dashboards/project-view/projectView.tsx
+++ b/frontend/src/dashboards/project-view/projectView.tsx
@@ -97,9 +97,9 @@ const ProjectView: React.FC<ProjectViewProps> = ({ project, onBack, updates, onS
             />
           )}
         </div>
-        <div className={styles.filesPanel}>
+        {!showingNotes && (<div className={styles.filesPanel}>
           <ProjectFiles projectId={project.id} />
-        </div>
+        </div>)}
 
         {showingNotes && (
           <ProjectNotes


### PR DESCRIPTION
https://github.com/Hack4Impact-UMD/winrock-international/issues/115


Hiding the Files when notes are open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Files panel now hides when viewing notes, allowing you to focus on note content without visual distractions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->