### PR TITLE
Remove share button

### DIFF
--- a/frontend/src/dashboards/supplier-project-view/components/ProjectViewHeader.tsx
+++ b/frontend/src/dashboards/supplier-project-view/components/ProjectViewHeader.tsx
@@ -36,14 +36,6 @@ const ProjectViewHeader: React.FC<ProjectViewHeaderProps> = ({ data, setShowAcce
             <div className={styles.titleContainer}>
 
                 <h1 className={styles.projectTitle}>{data.projectName}</h1>
-                <div className={styles.btnContainer}>
-                    <button
-                        className={styles.shareButton}
-                        onClick={() => { setShowAccessManager(true) }}
-                    >
-                        Share
-                    </button>
-                </div>
             </div>
             <table className={styles.table}>
               <thead className={styles.tableHeader}>


### PR DESCRIPTION
Addresses https://github.com/Hack4Impact-UMD/winrock-international/issues/141

Removed share accessibility on supplier end so they cannot add any more collaborators
<img width="1642" height="957" alt="image" src="https://github.com/user-attachments/assets/100998c0-1fef-4332-afaa-05044e03c1d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the Share button from the project view header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->