### PR TITLE
[BACKEND + FRONTEND] Add manual save to forms

### DIFF
--- a/frontend/src/forms/components/FormLock.tsx
+++ b/frontend/src/forms/components/FormLock.tsx
@@ -9,6 +9,18 @@ interface FormLockProps {
 }
 
 const FormLock = ({ projectName, onLockedAction, onUnlock }: FormLockProps) => {
+  const DISABLE_LOCK = true;
+
+  if (DISABLE_LOCK) {
+    return {
+      showLockedPopup: false,
+      handleLockedAction: () => {},
+      closePopup: () => {},
+      isLocked: false,
+      isLoading: false,
+      LockedPopup: null
+    };
+  }
   const [showLockedPopup, setShowLockedPopup] = useState(false);
   const [isLocked, setIsLocked] = useState(false);
   const [isLoading, setIsLoading] = useState(true);

--- a/frontend/src/forms/components/NavigationButtons.tsx
+++ b/frontend/src/forms/components/NavigationButtons.tsx
@@ -4,10 +4,12 @@ import styles from '../css-modules/NavigationButtons.module.css';
 interface NavigationButtonsProps {
    onNext?: () => void;
    onBack?: () => void;
+   onSave?: () => void;  // New prop for save functionality
    canGoNext?: boolean;
    canGoBack?: boolean;
    nextLabel?: string;
    backLabel?: string;
+   saveLabel?: string;  // New prop for save button label
    className?: string;
    disableSubmit?: boolean;
    isLastPage?: boolean;
@@ -16,10 +18,12 @@ interface NavigationButtonsProps {
 const NavigationButtons: React.FC<NavigationButtonsProps> = ({
    onNext,
    onBack,
+   onSave,  // New prop
    canGoNext = true,
    canGoBack = true,
    nextLabel = 'Next',
    backLabel = 'Back',
+   saveLabel = 'Save Progress',  // New prop with default
    className = '',
    disableSubmit = false,
    isLastPage = false,
@@ -33,6 +37,12 @@ const NavigationButtons: React.FC<NavigationButtonsProps> = ({
    const handleBackClick = () => {
       if (onBack) {
          onBack();
+      }
+   };
+
+   const handleSaveClick = () => {
+      if (onSave) {
+         onSave();
       }
    };
 
@@ -54,6 +64,19 @@ const NavigationButtons: React.FC<NavigationButtonsProps> = ({
          );
       }
 
+      // Save Progress Button (new)
+      if (onSave) {
+         buttons.push(
+            <button
+               key="save"
+               className={`${styles.navigationButton} ${styles.saveButton}`}
+               onClick={handleSaveClick}
+               aria-label={saveLabel}
+            >
+               {saveLabel}
+            </button>
+         );
+      }
 
       // Next Button (Submit Button)
       if (onNext) {

--- a/frontend/src/forms/project-proposal-forms/AgricultureProposalForm.tsx
+++ b/frontend/src/forms/project-proposal-forms/AgricultureProposalForm.tsx
@@ -2,6 +2,8 @@ import { useRef, useState } from "react";
 import * as firestore from "firebase/firestore";
 import { db } from "../../firebaseConfig.js";
 import FormField from "../FormField.js";
+import { collection, addDoc, updateDoc, doc, query, where, getDocs } from "firebase/firestore";
+import { useEffect } from "react";
 
 import LogoHeader from "../components/headers/LogoHeader.js";
 import TitleHeader from "../components/headers/TitleHeader.js";
@@ -95,6 +97,7 @@ function AgricultureProposalForm() {
 
     const [currentPage, setCurrentPage] = useState(1);
     const totalPages = 4;
+    const [, forceRender] = useState(0);
 
     const collectionID = "agriculture-proposal-form";
     const collectionRef = firestore.collection(db, collectionID);
@@ -159,7 +162,7 @@ function AgricultureProposalForm() {
             [field]: new FormField(value, isRequired)
         }
         // Auto-save whenever form changes
-        saveChanges();
+        // saveChanges();
     }
 
     const [isSubmitted, setIsSubmitted] = useState(false);
@@ -170,6 +173,84 @@ function AgricultureProposalForm() {
     const { handleLockedAction, LockedPopup, isLocked } = FormLock({
         projectName: projectName!,
     });
+
+    const [saveMessage, setSaveMessage] = useState('');
+    const [isSaving, setIsSaving] = useState(false);
+    const [documentId, setDocumentId] = useState<string | null>(null);
+
+    // finding the existing document
+    useEffect(() => {
+        const findExistingDocument = async () => {
+            if (projectName) {
+                try {
+                    const q = query(
+                        collectionRef,
+                        where("projectName", "==", projectName)
+                    );
+                    const querySnapshot = await getDocs(q);
+                    
+                    if (!querySnapshot.empty) {
+                        // Found existing document with this project name
+                        setDocumentId(querySnapshot.docs[0].id);
+                        
+                        // Optional: Load existing data into the form
+                        const existingData = querySnapshot.docs[0].data();
+                        Object.keys(answersRef.current).forEach((field) => {
+                            if (existingData[field]) {
+                                answersRef.current[field as keyof AgricultureProposalFormData]!.value = existingData[field];
+                            }
+                        });
+                        forceRender(x => x + 1);
+                    }
+                } catch (error) {
+                    console.error("Error finding existing document:", error);
+                }
+            }
+        };
+        
+        findExistingDocument();
+    }, [projectName]);
+
+    const saveChanges = async () => {
+        setIsSaving(true);
+        setSaveMessage('');
+        
+        try {
+            const submissionObj: Record<string, string> = {
+                projectName: projectName || '' 
+            };
+            Object.keys(answersRef.current).forEach((field) => {
+                submissionObj[field] = answersRef.current[field as keyof AgricultureProposalFormData]!.value;
+            });
+
+            if (documentId) {
+                // Update existing document
+                const docRef = doc(db, collectionID, documentId);
+                await updateDoc(docRef, submissionObj);
+                setSaveMessage('Progress updated successfully! Feel free to exit page.');
+            } else {
+                // Create new document and store its ID
+                const docRef = await addDoc(collectionRef, submissionObj);
+                setDocumentId(docRef.id);
+                setSaveMessage('Progress saved successfully! Feel free to exit page.');
+            }
+
+            setTimeout(() => {
+                setSaveMessage('');
+            }, 3000);
+            
+        } catch (error) {
+            console.error("Error saving progress:", error);
+            setSaveMessage('Error saving progress. Please try again.');
+            setTimeout(() => {
+                setSaveMessage('');
+            }, 3000);
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
+
 
     /**
      * Insert a new AgricultureProjectProposal document with the user-inputted
@@ -197,10 +278,7 @@ function AgricultureProposalForm() {
         }
     }
 
-    const saveChanges = () => {
-        // TODO: Implement save functionality
-        console.log('Changes saved');
-    }
+    
 
 
     if (isSubmitted) {
@@ -933,6 +1011,18 @@ function AgricultureProposalForm() {
                     </div>
                 </>
             )}
+
+            {saveMessage && (
+                <div style={{ 
+                    color: saveMessage.includes('Error') ? 'red' : 'green',
+                    textAlign: 'center', 
+                    padding: '10px',
+                    margin: '10px 0',
+                    fontWeight: 'bold'
+                }}>
+                    {saveMessage}
+                </div>
+            )}
             <NavigationButtons
                 onNext={() => {
                     if (isLocked) {
@@ -955,6 +1045,13 @@ function AgricultureProposalForm() {
                         setCurrentPage(currentPage - 1)
                         window.scroll(0, 0);
                     }
+                }}
+                onSave={() => {  // New save handler
+                    // if (isLocked) {
+                    //     handleLockedAction();
+                    //     return;
+                    // }
+                    saveChanges();
                 }}
                 canGoBack={currentPage > 1}
                 nextLabel={currentPage === totalPages ? 'Submit' : 'Next'}

--- a/frontend/src/forms/project-proposal-forms/RenewableProposalForm.tsx
+++ b/frontend/src/forms/project-proposal-forms/RenewableProposalForm.tsx
@@ -15,6 +15,8 @@ import GuidanceDropdown from "../components/GuidanceDropdown.tsx";
 import FormLock from "../components/FormLock.js";
 import tableImage from '../../assets/table.png';
 import { useParams } from "react-router-dom";
+import { collection, addDoc, updateDoc, doc, query, where, getDocs } from "firebase/firestore";
+import { useEffect } from "react";
 
 interface RenewableProposalFormData {
     parentVendorName: FormField;
@@ -46,6 +48,7 @@ const RenewableProposalForm = () => {
 
     const [currentPage, setCurrentPage] = useState(1); // Start on Page 1
     const totalPages = 2; // Set totalPages to 2 since we have two pages
+    const [, forceRender] = useState(0);
 
     const collectionID = "project-proposal-form";
     const collectionRef = firestore.collection(db, collectionID);
@@ -96,8 +99,85 @@ const RenewableProposalForm = () => {
             [field]: new FormField(value, isRequired),
         };
         // Auto-save whenever form changes
-        saveChanges();
+        //saveChanges();
     };
+
+    const [saveMessage, setSaveMessage] = useState('');
+    const [isSaving, setIsSaving] = useState(false);
+    const [documentId, setDocumentId] = useState<string | null>(null);
+
+    // finding the existing document
+    useEffect(() => {
+        const findExistingDocument = async () => {
+            if (projectName) {
+                try {
+                    const q = query(
+                        collectionRef,
+                        where("projectName", "==", projectName)
+                    );
+                    const querySnapshot = await getDocs(q);
+                    
+                    if (!querySnapshot.empty) {
+                        // Found existing document with this project name
+                        setDocumentId(querySnapshot.docs[0].id);
+                        
+                        // Optional: Load existing data into the form
+                        const existingData = querySnapshot.docs[0].data();
+                        Object.keys(answersRef.current).forEach((field) => {
+                            if (existingData[field]) {
+                                answersRef.current[field as keyof RenewableProposalFormData]!.value = existingData[field];
+                            }
+                        });
+                        forceRender(x => x + 1);
+                    }
+                } catch (error) {
+                    console.error("Error finding existing document:", error);
+                }
+            }
+        };
+        
+        findExistingDocument();
+    }, [projectName]);
+
+    const saveChanges = async () => {
+        setIsSaving(true);
+        setSaveMessage('');
+        
+        try {
+            const submissionObj: Record<string, string> = {
+                projectName: projectName || '' 
+            };
+            Object.keys(answersRef.current).forEach((field) => {
+                submissionObj[field] = answersRef.current[field as keyof RenewableProposalFormData]!.value;
+            });
+
+            if (documentId) {
+                // Update existing document
+                const docRef = doc(db, collectionID, documentId);
+                await updateDoc(docRef, submissionObj);
+                setSaveMessage('Progress updated successfully! Feel free to exit page.');
+            } else {
+                // Create new document and store its ID
+                const docRef = await addDoc(collectionRef, submissionObj);
+                setDocumentId(docRef.id);
+                setSaveMessage('Progress saved successfully! Feel free to exit page.');
+            }
+
+            setTimeout(() => {
+                setSaveMessage('');
+            }, 3000);
+            
+        } catch (error) {
+            console.error("Error saving progress:", error);
+            setSaveMessage('Error saving progress. Please try again.');
+            setTimeout(() => {
+                setSaveMessage('');
+            }, 3000);
+        } finally {
+            setIsSaving(false);
+        }
+    }
+    
 
     // Handling form submission
     const handleSubmit = async () => {
@@ -120,11 +200,6 @@ const RenewableProposalForm = () => {
             setError("Server error. Please try again later.");
         }
     };
-
-    const saveChanges = () => {
-        // TODO: Implement save functionality
-        console.log('Changes saved');
-    }
 
     // Navigate to Confirmation Page
     if (isSubmitted) {
@@ -256,6 +331,18 @@ const RenewableProposalForm = () => {
                 </div>
             )}
 
+            {saveMessage && (
+                <div style={{ 
+                    color: saveMessage.includes('Error') ? 'red' : 'green',
+                    textAlign: 'center', 
+                    padding: '10px',
+                    margin: '10px 0',
+                    fontWeight: 'bold'
+                }}>
+                    {saveMessage}
+                </div>
+            )}
+
             {/* Navigation Buttons */}
             <NavigationButtons
                 onNext={() => {
@@ -277,6 +364,9 @@ const RenewableProposalForm = () => {
                     if (currentPage > 1) {
                         setCurrentPage(currentPage - 1); // Update page when Back is clicked
                     }
+                }}
+                onSave={() => {
+                    saveChanges();
                 }}
                 canGoBack={currentPage > 1}
                 nextLabel={currentPage === totalPages ? 'Submit' : 'Next'}

--- a/frontend/src/forms/risks-and-co-benefit-forms/ForestryRisksForm.tsx
+++ b/frontend/src/forms/risks-and-co-benefit-forms/ForestryRisksForm.tsx
@@ -14,6 +14,8 @@ import ConfirmationPage from '../ConfirmationPage.js'
 import Error from '../components/Error.js'
 import FormLock from '../components/FormLock.js'
 import { useParams } from 'react-router-dom'
+import { collection, addDoc, updateDoc, doc, query, where, getDocs } from "firebase/firestore";
+import { useEffect } from "react";
 
 interface ForestryRisksFormData {
    // Risk Assessment
@@ -98,6 +100,7 @@ function ForestryRisksForm() {
 
    const [currentPage, setCurrentPage] = useState(1)
    const totalPages = 3
+   const [, forceRender] = useState(0);
 
    const collectionID = "forestry-risks-form"
    const collectionRef = firestore.collection(db, collectionID)
@@ -165,14 +168,90 @@ function ForestryRisksForm() {
 
       answersRef.current[field]!.value = value;
       // Auto-save whenever form changes
-      saveChanges();
+      //saveChanges();
+   }
+   const [saveMessage, setSaveMessage] = useState('');
+   const [isSaving, setIsSaving] = useState(false);
+   const [documentId, setDocumentId] = useState<string | null>(null);
+   const { projectName } = useParams(); // TODO: Replace with actual projectId from form data or props
+
+
+   // finding the existing document
+   useEffect(() => {
+      const findExistingDocument = async () => {
+         if (projectName) {
+               try {
+                  const q = query(
+                     collectionRef,
+                     where("projectName", "==", projectName)
+                  );
+                  const querySnapshot = await getDocs(q);
+                  
+                  if (!querySnapshot.empty) {
+                     // Found existing document with this project name
+                     setDocumentId(querySnapshot.docs[0].id);
+                     
+                     // Optional: Load existing data into the form
+                     const existingData = querySnapshot.docs[0].data();
+                     Object.keys(answersRef.current).forEach((field) => {
+                           if (existingData[field]) {
+                              answersRef.current[field as keyof ForestryRisksFormData]!.value = existingData[field];
+                           }
+                     });
+                     forceRender(x => x + 1);
+                  }
+               } catch (error) {
+                  console.error("Error finding existing document:", error);
+               }
+         }
+      };
+      
+      findExistingDocument();
+   }, [projectName]);
+
+   const saveChanges = async () => {
+      setIsSaving(true);
+      setSaveMessage('');
+      
+      try {
+         const submissionObj: Record<string, string> = {
+               projectName: projectName || '' 
+         };
+         Object.keys(answersRef.current).forEach((field) => {
+               submissionObj[field] = answersRef.current[field as keyof ForestryRisksFormData]!.value;
+         });
+
+         if (documentId) {
+               // Update existing document
+               const docRef = doc(db, collectionID, documentId);
+               await updateDoc(docRef, submissionObj);
+               setSaveMessage('Progress updated successfully! Feel free to exit page.');
+         } else {
+               // Create new document and store its ID
+               const docRef = await addDoc(collectionRef, submissionObj);
+               setDocumentId(docRef.id);
+               setSaveMessage('Progress saved successfully! Feel free to exit page.');
+         }
+
+         setTimeout(() => {
+               setSaveMessage('');
+         }, 3000);
+         
+      } catch (error) {
+         console.error("Error saving progress:", error);
+         setSaveMessage('Error saving progress. Please try again.');
+         setTimeout(() => {
+               setSaveMessage('');
+         }, 3000);
+      } finally {
+         setIsSaving(false);
+      }
    }
 
    const [isSubmitted, setIsSubmitted] = useState(false)
    const [error, setError] = useState('')
 
    // Initialize form lock
-   const { projectName } = useParams(); // TODO: Replace with actual projectId from form data or props
    const { handleLockedAction, LockedPopup, isLocked } = FormLock({
       projectName: projectName!,
    });
@@ -202,11 +281,6 @@ function ForestryRisksForm() {
          console.error("Error submitting ForestryRisksForm", error)
          setError("Server error. Please try again later.")
       }
-   }
-
-   const saveChanges = () => {
-      // TODO: Implement save functionality
-      console.log('Changes saved');
    }
 
 
@@ -249,7 +323,17 @@ function ForestryRisksForm() {
                isLocked={isLocked}
             />
          }
-
+         {saveMessage && (
+               <div style={{ 
+                  color: saveMessage.includes('Error') ? 'red' : 'green',
+                  textAlign: 'center', 
+                  padding: '10px',
+                  margin: '10px 0',
+                  fontWeight: 'bold'
+               }}>
+                  {saveMessage}
+               </div>
+         )}
          <NavigationButtons
             onNext={() => {
                if (currentPage < totalPages) {
@@ -269,6 +353,9 @@ function ForestryRisksForm() {
                   setCurrentPage(currentPage - 1)
                   window.scroll(0, 0)
                }
+            }}
+            onSave={() => {
+               saveChanges();
             }}
             canGoBack={currentPage > 1}
             nextLabel={currentPage === totalPages ? 'Submit' : 'Next'}

--- a/frontend/src/forms/risks-and-co-benefit-forms/RegenAgRisksForm.tsx
+++ b/frontend/src/forms/risks-and-co-benefit-forms/RegenAgRisksForm.tsx
@@ -13,6 +13,8 @@ import ConfirmationPage from '../ConfirmationPage.js';
 import Error from '../components/Error.js';
 import FormLock from '../components/FormLock.js';
 import { useParams } from 'react-router-dom';
+import { collection, addDoc, updateDoc, doc, query, where, getDocs } from "firebase/firestore";
+import { useEffect } from "react";
 
 interface TechEnergyRisksFormData {
     // Risk Assessment
@@ -83,6 +85,7 @@ function RegenAgRisksForm() {
 
     const [currentPage, setCurrentPage] = useState(1);
     const totalPages = 2;
+    const [, forceRender] = useState(0);
 
     const collectionID = "regenerative-agriculture-risks";
     const collectionRef = firestore.collection(db, collectionID);
@@ -142,7 +145,7 @@ function RegenAgRisksForm() {
             [field]: new FormField(value, isRequired)
         }
         // Auto-save whenever form changes
-        saveChanges();
+        //saveChanges();
     }
 
     const [isSubmitted, setIsSubmitted] = useState(false);
@@ -153,6 +156,83 @@ function RegenAgRisksForm() {
     const { handleLockedAction, LockedPopup, isLocked } = FormLock({
         projectName: projectName!
     });
+
+    const [saveMessage, setSaveMessage] = useState('');
+    const [isSaving, setIsSaving] = useState(false);
+    const [documentId, setDocumentId] = useState<string | null>(null);
+
+
+    // finding the existing document
+    useEffect(() => {
+        const findExistingDocument = async () => {
+            if (projectName) {
+                try {
+                    const q = query(
+                        collectionRef,
+                        where("projectName", "==", projectName)
+                    );
+                    const querySnapshot = await getDocs(q);
+                    
+                    if (!querySnapshot.empty) {
+                        // Found existing document with this project name
+                        setDocumentId(querySnapshot.docs[0].id);
+                        
+                        // Optional: Load existing data into the form
+                        const existingData = querySnapshot.docs[0].data();
+                        Object.keys(answersRef.current).forEach((field) => {
+                            if (existingData[field]) {
+                                answersRef.current[field as keyof TechEnergyRisksFormData]!.value = existingData[field];
+                            }
+                        });
+                        forceRender(x => x + 1);
+                    }
+                } catch (error) {
+                    console.error("Error finding existing document:", error);
+                }
+            }
+        };
+        
+        findExistingDocument();
+    }, [projectName]);
+
+    const saveChanges = async () => {
+        setIsSaving(true);
+        setSaveMessage('');
+        
+        try {
+            const submissionObj: Record<string, string> = {
+                projectName: projectName || '' 
+            };
+            Object.keys(answersRef.current).forEach((field) => {
+                submissionObj[field] = answersRef.current[field as keyof TechEnergyRisksFormData]!.value;
+            });
+
+            if (documentId) {
+                // Update existing document
+                const docRef = doc(db, collectionID, documentId);
+                await updateDoc(docRef, submissionObj);
+                setSaveMessage('Progress updated successfully! Feel free to exit page.');
+            } else {
+                // Create new document and store its ID
+                const docRef = await addDoc(collectionRef, submissionObj);
+                setDocumentId(docRef.id);
+                setSaveMessage('Progress saved successfully! Feel free to exit page.');
+            }
+
+            setTimeout(() => {
+                setSaveMessage('');
+            }, 3000);
+            
+        } catch (error) {
+            console.error("Error saving progress:", error);
+            setSaveMessage('Error saving progress. Please try again.');
+            setTimeout(() => {
+                setSaveMessage('');
+            }, 3000);
+        } finally {
+            setIsSaving(false);
+        }
+    }
 
     /**
     * Insert a new TechEnergyRisksForm submission with the user-inputted
@@ -179,11 +259,6 @@ function RegenAgRisksForm() {
             console.error("Error submitting TechEnergyRisksForm", error);
             setError("Server error. Please try again later.");
         }
-    }
-
-    const saveChanges = () => {
-        // TODO: Implement save functionality
-        console.log('Changes saved');
     }
 
 
@@ -217,7 +292,17 @@ function RegenAgRisksForm() {
                     answersRef={answersRef}
                     locked={isLocked}
                 />}
-
+            {saveMessage && (
+                <div style={{ 
+                    color: saveMessage.includes('Error') ? 'red' : 'green',
+                    textAlign: 'center', 
+                    padding: '10px',
+                    margin: '10px 0',
+                    fontWeight: 'bold'
+                }}>
+                    {saveMessage}
+                </div>
+            )}
             <NavigationButtons
                 onNext={() => {
                     if (currentPage < totalPages) {
@@ -237,6 +322,9 @@ function RegenAgRisksForm() {
                         setCurrentPage(currentPage - 1)
                         window.scroll(0, 0);
                     }
+                }}
+                onSave={() => {
+                    saveChanges();
                 }}
                 canGoBack={currentPage > 1}
                 nextLabel={currentPage === totalPages ? 'Submit' : 'Next'}

--- a/frontend/src/forms/risks-and-co-benefit-forms/TechEnergyRisksForm.tsx
+++ b/frontend/src/forms/risks-and-co-benefit-forms/TechEnergyRisksForm.tsx
@@ -14,6 +14,8 @@ import ConfirmationPage from '../ConfirmationPage.js';
 import Error from '../components/Error.js';
 import FormLock from '../components/FormLock.js';
 import { useParams } from 'react-router-dom';
+import { collection, addDoc, updateDoc, doc, query, where, getDocs } from "firebase/firestore";
+import { useEffect } from "react";
 
 interface TechEnergyRisksFormData {
   // Risk Assessment
@@ -88,6 +90,7 @@ function TechEnergyRisksForm() {
 
   const [currentPage, setCurrentPage] = useState(1);
   const totalPages = 3;
+  const [, forceRender] = useState(0);
 
   const collectionID = "tech-and-energy-form";
   const collectionRef = firestore.collection(db, collectionID);
@@ -157,6 +160,83 @@ function TechEnergyRisksForm() {
     projectName: projectName!
   });
 
+  const [saveMessage, setSaveMessage] = useState('');
+    const [isSaving, setIsSaving] = useState(false);
+    const [documentId, setDocumentId] = useState<string | null>(null);
+
+
+    // finding the existing document
+    useEffect(() => {
+        const findExistingDocument = async () => {
+            if (projectName) {
+                try {
+                    const q = query(
+                        collectionRef,
+                        where("projectName", "==", projectName)
+                    );
+                    const querySnapshot = await getDocs(q);
+                    
+                    if (!querySnapshot.empty) {
+                        // Found existing document with this project name
+                        setDocumentId(querySnapshot.docs[0].id);
+                        
+                        // Optional: Load existing data into the form
+                        const existingData = querySnapshot.docs[0].data();
+                        Object.keys(answersRef.current).forEach((field) => {
+                            if (existingData[field]) {
+                                answersRef.current[field as keyof TechEnergyRisksFormData]!.value = existingData[field];
+                            }
+                        });
+                        forceRender(x => x + 1);
+                    }
+                } catch (error) {
+                    console.error("Error finding existing document:", error);
+                }
+            }
+        };
+        
+        findExistingDocument();
+    }, [projectName]);
+
+    const saveChanges = async () => {
+        setIsSaving(true);
+        setSaveMessage('');
+        
+        try {
+            const submissionObj: Record<string, string> = {
+                projectName: projectName || '' 
+            };
+            Object.keys(answersRef.current).forEach((field) => {
+                submissionObj[field] = answersRef.current[field as keyof TechEnergyRisksFormData]!.value;
+            });
+
+            if (documentId) {
+                // Update existing document
+                const docRef = doc(db, collectionID, documentId);
+                await updateDoc(docRef, submissionObj);
+                setSaveMessage('Progress updated successfully! Feel free to exit page.');
+            } else {
+                // Create new document and store its ID
+                const docRef = await addDoc(collectionRef, submissionObj);
+                setDocumentId(docRef.id);
+                setSaveMessage('Progress saved successfully! Feel free to exit page.');
+            }
+
+            setTimeout(() => {
+                setSaveMessage('');
+            }, 3000);
+            
+        } catch (error) {
+            console.error("Error saving progress:", error);
+            setSaveMessage('Error saving progress. Please try again.');
+            setTimeout(() => {
+                setSaveMessage('');
+            }, 3000);
+        } finally {
+            setIsSaving(false);
+        }
+    }
+
   /**
   * Insert a new TechEnergyRisksForm submission with the user-inputted
   * fields into the TechEnergyRisksForm collection.
@@ -182,11 +262,6 @@ function TechEnergyRisksForm() {
       console.error("Error submitting TechEnergyRisksForm", error);
       setError("Server error. Please try again later.");
     }
-  }
-
-  const saveChanges = () => {
-    // TODO: Implement save functionality
-    console.log('Changes saved');
   }
 
 
@@ -246,6 +321,9 @@ function TechEnergyRisksForm() {
             setCurrentPage(currentPage - 1)
             window.scroll(0, 0);
           }
+        }}
+        onSave={() => {
+          saveChanges();
         }}
         canGoBack={currentPage > 1}
         nextLabel={currentPage === totalPages ? 'Submit' : 'Next'}


### PR DESCRIPTION
Addresses: https://github.com/Hack4Impact-UMD/winrock-international/issues/152
- Disabled form lock
- Added manual save to all forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Save Progress button to form navigation for explicit data persistence
  * Forms now automatically save and retrieve previously entered data when revisited
  * Implemented visual save status feedback with success and error messaging that auto-clears
  * Enhanced proposal and risk assessment forms with persistent data storage capabilities
  * Forms pre-fill with previously saved information upon reopening

<!-- end of auto-generated comment: release notes by coderabbit.ai -->