### PR TITLE
[FRONTEND] Fix agriculture form sub-ingredient fields being linked

### DIFF
--- a/frontend/src/forms/project-proposal-forms/AgricultureProposalForm.tsx
+++ b/frontend/src/forms/project-proposal-forms/AgricultureProposalForm.tsx
@@ -26,6 +26,7 @@ interface AgricultureProposalFormData {
     // Ingredient/Crop Supplied
     ingredientPrimary: FormField;
     ingredientSub: FormField;
+	ingredientSubAdditional: FormField;
 
     // General Project Activity Description
     mainIntervention: FormField;
@@ -104,6 +105,7 @@ function AgricultureProposalForm() {
     const answersRef = useRef<AgricultureProposalFormData>({
         ingredientPrimary: new FormField('', true),
         ingredientSub: new FormField('', true),
+		ingredientSubAdditional: new FormField('', true),
         mainIntervention: new FormField('', true),
         projectDescription: new FormField('', true),
         averageVolumePurchased: new FormField('', true),
@@ -391,8 +393,8 @@ function AgricultureProposalForm() {
 
                     <TextQuestion
                         label="List additional ones here manually (if applicable)"
-                        controlledValue={answersRef.current.ingredientSub.value}  // Adjust based on actual data structure if needed
-                        onChange={(value) => handleChange("ingredientSub", value)}  // Adjust based on actual data structure if needed
+                        controlledValue={answersRef.current.ingredientSubAdditional.value}  // Adjust based on actual data structure if needed
+                        onChange={(value) => handleChange("ingredientSubAdditional", value)}  // Adjust based on actual data structure if needed
                         size="small"
                         disabled={isLocked}
                     />


### PR DESCRIPTION
## Summary
- Closes #151 
- The sub-category dropdown and additional info textbox are no longer tied to the same value

## Screenshot
<img width="910" height="239" alt="Screenshot 2025-11-17 at 8 50 37 PM" src="https://github.com/user-attachments/assets/869fa70c-dd56-430b-9159-8b2b4e3157b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of manually entered additional ingredients in the Agriculture Proposal Form to ensure proper data tracking and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->