### PR TITLE
Fix form lock

### DIFF
--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -2,6 +2,12 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    match /form-locks/{lockId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null
+                   && request.resource.data.lockedBy == request.auth.uid;
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }

--- a/frontend/src/dashboards/winrock-dashboard/projects/winrockDashboardService.ts
+++ b/frontend/src/dashboards/winrock-dashboard/projects/winrockDashboardService.ts
@@ -396,58 +396,64 @@ const deleteProject = async (projectName: string): Promise<Result> => {
         return handleFirebaseError(error);
     }
 };
+const LOCK_STALE_MS = 30_000;
 
-/**
- * Check if a project is locked for editing
+/*
+locks the form by checking firestore & acting accordingly
  */
-const checkProjectLock = async (projectName: string): Promise<Result> => {
+const lockForm = async (projectId: string, formId: string, userId: string): Promise<Result> => {
     try {
-        const projectsRef = collection(db, "projects");
-        const q = query(projectsRef, where("projectName", "==", projectName.toLowerCase()));
-        const querySnapshot = await getDocs(q);
+        const lockDocRef = doc(db, "form-locks", `${projectId}_${formId}`);
 
-        if (querySnapshot.empty) {
-            return { success: false, errorCode: "project-not-found" };
+        await runTransaction(db, async (tx) => {
+            const snap = await tx.get(lockDocRef);
+            const lockData = snap.data();
+
+            if (lockData?.isLocked && lockData?.lockedBy !== userId) {
+                // Check if the lock is stale
+                const lockedAt = lockData.lockedAt?.toMillis?.() ?? 0;
+                const now = Date.now();
+                if (now - lockedAt < LOCK_STALE_MS) {
+                    throw new Error("form-already-locked");
+                }
+                // Lock is stale — take it over
+            }
+
+            tx.set(lockDocRef, {
+                isLocked: true,
+                lockedBy: userId,
+                lockedAt: serverTimestamp(),
+                projectId,
+                formId,
+            });
+        });
+
+        return { success: true };
+    } catch (error: any) {
+        if (error?.message === "form-already-locked") {
+            return { success: false, errorCode: "form-already-locked" };
         }
-
-        // Assuming projectName is unique, take the first match
-        const projectData = querySnapshot.docs[0].data();
-        const isLocked = projectData.isLocked ?? false;
-
-        return {
-            success: true,
-            data: { isLocked },
-        };
-    } catch (error) {
         return handleFirebaseError(error);
     }
 };
 
-/**
- * Lock a project for editing (set isLocked to true)
- */
-const lockProject = async (projectName: string): Promise<Result> => {
+/*
+keeps the form locking consistent
+*/
+const refreshFormLock = async (projectId: string, formId: string, userId: string): Promise<Result> => {
     try {
-        // first get the doc ID by projectName
-        const q = query(collection(db, "projects"), where("projectName", "==", projectName.toLowerCase()));
-        const querySnapshot = await getDocs(q);
-        if (querySnapshot.empty) {
-            return { success: false, errorCode: "project-not-found" };
-        }
-
-        const docRef = querySnapshot.docs[0].ref; // use actual doc ref
+        const lockDocRef = doc(db, "form-locks", `${projectId}_${formId}`);
 
         await runTransaction(db, async (tx) => {
-            const snap = await tx.get(docRef);
-            const projectData = snap.data();
+            const snap = await tx.get(lockDocRef);
+            const lockData = snap.data();
 
-            if (projectData?.isLocked) {
-                throw new Error("project-already-locked");
+            if (!lockData?.isLocked || lockData?.lockedBy !== userId) {
+                return;
             }
 
-            tx.update(docRef, {
-                isLocked: true,
-                lastUpdated: serverTimestamp()
+            tx.update(lockDocRef, {
+                lockedAt: serverTimestamp(),
             });
         });
 
@@ -457,23 +463,27 @@ const lockProject = async (projectName: string): Promise<Result> => {
     }
 };
 
-/**
- * Unlock a project (set isLocked to false)
- */
-const unlockProject = async (projectName: string): Promise<Result> => {
+/*
+locks a specific form
+*/
+const unlockForm = async (projectId: string, formId: string, userId: string): Promise<Result> => {
     try {
-        const q = query(collection(db, "projects"), where("projectName", "==", projectName.toLowerCase()));
-        const querySnapshot = await getDocs(q);
-        if (querySnapshot.empty) {
-            return { success: false, errorCode: "project-not-found" };
-        }
-
-        const docRef = querySnapshot.docs[0].ref;
+        const lockDocRef = doc(db, "form-locks", `${projectId}_${formId}`);
 
         await runTransaction(db, async (tx) => {
-            tx.update(docRef, {
+            const snap = await tx.get(lockDocRef);
+            const lockData = snap.data();
+
+            if (lockData?.lockedBy !== userId) {
+                return;
+            }
+
+            tx.set(lockDocRef, {
                 isLocked: false,
-                lastUpdated: serverTimestamp()
+                lockedBy: null,
+                lockedAt: null,
+                projectId,
+                formId,
             });
         });
 
@@ -531,7 +541,7 @@ export {
     getProjectsWithFilters,
     updateProjectField,
     deleteProject,
-    checkProjectLock,
-    lockProject,
-    unlockProject,
+    lockForm,
+    refreshFormLock,
+    unlockForm,
 };

--- a/frontend/src/forms/FormViewer.tsx
+++ b/frontend/src/forms/FormViewer.tsx
@@ -6,11 +6,13 @@ import DropdownQuestion from "./components/questions/DropdownQuestion";
 import TextQuestion from "./components/questions/TextQuestion";
 import { db } from "../firebaseConfig";
 import { doc, getDoc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { getAuth } from "firebase/auth";
 import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Sidebar from "../dashboards/winrock-dashboard/components/Sidebar";
 import styles from "./css-modules/FormViewer.module.css";
 import { useSearchParams } from "react-router-dom";
+import FormLock from "./components/FormLock";
 
 interface Question {
     label: string;
@@ -32,12 +34,21 @@ const FormViewer = () => {
     const { formType, id, projectID } = useParams<{ formType: string; id: string; projectID: string }>();
     const [form, setForm] = useState<FormStructure | null>(null);
     const [loading, setLoading] = useState(true);
-    const [saveMessage, setSaveMessage] = useState(""); // Add this at the top with other state
-
+    const [saveMessage, setSaveMessage] = useState("");
 
     const [searchParams] = useSearchParams();
     const editable = searchParams.get("editable") === "true";
-    const readOnly = !editable;
+
+    const auth = getAuth();
+    const userId = auth.currentUser?.uid || "";
+
+    const { isLocked, isLoading: lockLoading, doUnlock, LockedPopup } = FormLock({
+        projectId: projectID || "",
+        formId: id || "",
+        userId,
+    });
+
+    const readOnly = !editable || isLocked;
     const pages: Question[][] = [];
     let currentPage: Question[] = [];
     const [currentPageIndex, setCurrentPageIndex] = useState(0);
@@ -63,6 +74,7 @@ const FormViewer = () => {
                 },
                 { merge: true }
             );
+            doUnlock();
             setSaveMessage("Form saved successfully!");
             setTimeout(() => setSaveMessage(""), 3000);
         } catch (err) {
@@ -112,7 +124,7 @@ const FormViewer = () => {
         fetchForm();
     }, [id, formType, projectID]);
 
-    if (loading) return <div className={styles.centeredState}>Loading form...</div>;
+    if (loading || lockLoading) return <div className={styles.centeredState}>Loading form...</div>;
     if (!form) return <div className={styles.centeredState}>Form not found.</div>;
 
     form.questions.forEach(q => {
@@ -131,6 +143,7 @@ const FormViewer = () => {
 
     return (
         <div className={styles.pageWrapper}>
+            {LockedPopup}
             <Sidebar currentTab="forms" />
 
             <main className={styles.mainContent}>

--- a/frontend/src/forms/SupplierFormViewer.tsx
+++ b/frontend/src/forms/SupplierFormViewer.tsx
@@ -32,7 +32,7 @@ const SupplierFormViewer = () => {
     const { formType, id, projectID } = useParams<{ formType: string; id: string; projectID: string }>();
     const [form, setForm] = useState<FormStructure | null>(null);
     const [loading, setLoading] = useState(true);
-    const [saveMessage, setSaveMessage] = useState(""); // Add this at the top with other state
+    const [saveMessage, setSaveMessage] = useState("");
     const [searchParams] = useSearchParams();
     const editable = searchParams.get("editable") === "true";
     const readOnly = !editable;

--- a/frontend/src/forms/components/FormLock.tsx
+++ b/frontend/src/forms/components/FormLock.tsx
@@ -1,98 +1,122 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { checkProjectLock, lockProject, unlockProject } from '../../dashboards/winrock-dashboard/projects/winrockDashboardService';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '../../firebaseConfig';
+import { lockForm, refreshFormLock, unlockForm } from '../../dashboards/winrock-dashboard/projects/winrockDashboardService';
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
 
 interface FormLockProps {
-  projectName: string;
+  projectId: string;
+  formId: string;
+  userId: string;
   onLockedAction?: () => void;
   onUnlock?: () => void;
 }
 
-const FormLock = ({ projectName, onLockedAction, onUnlock }: FormLockProps) => {
-  const DISABLE_LOCK = true;
-
-  if (DISABLE_LOCK) {
-    return {
-      showLockedPopup: false,
-      handleLockedAction: () => { },
-      closePopup: () => { },
-      isLocked: false,
-      isLoading: false,
-      LockedPopup: null
-    };
-  }
+const FormLock = ({ projectId, formId, userId, onLockedAction, onUnlock }: FormLockProps) => {
   const [showLockedPopup, setShowLockedPopup] = useState(false);
   const [isLocked, setIsLocked] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const navigate = useNavigate();
-  // Check project lock status and attempt to lock if not locked
+  const didLockRef = useRef(false);
+  const attemptingRef = useRef(false);
+
+  const doUnlock = useCallback(() => {
+    if (projectId && formId && didLockRef.current) {
+      didLockRef.current = false;
+      unlockForm(projectId, formId, userId).catch(error => {
+        console.error('Failed to unlock form:', error);
+      });
+    }
+  }, [projectId, formId, userId]);
+
+  const attemptLock = useCallback(async () => {
+    if (!projectId || !formId || !userId || attemptingRef.current) return;
+
+    attemptingRef.current = true;
+    try {
+      const result = await lockForm(projectId, formId, userId);
+
+      if (result.success) {
+        didLockRef.current = true;
+        setIsLocked(false);
+        setShowLockedPopup(false);
+        if (onUnlock) {
+          onUnlock();
+        }
+      } else if (result.errorCode === 'form-already-locked') {
+        setIsLocked(true);
+        setShowLockedPopup(true);
+      } else {
+        console.error('Failed to lock form:', result.errorCode);
+      }
+    } catch (error) {
+      console.error('Error in form locking logic:', error);
+    } finally {
+      setIsLoading(false);
+      attemptingRef.current = false;
+    }
+  }, [projectId, formId, userId, onUnlock]);
+
+  // Initial lock attempt on mount
   useEffect(() => {
-    const checkAndLockProject = async () => {
-      if (!projectName) {
-        setIsLoading(false);
-        return;
-      }
+    if (!projectId || !formId || !userId) {
+      setIsLoading(false);
+      return;
+    }
 
-      try {
-        setIsLoading(true);
+    setIsLoading(true);
+    attemptLock();
 
-        // First check if project is already locked
-        const lockCheckResult = await checkProjectLock(projectName.toLowerCase());
-
-        if (!lockCheckResult.success) {
-          console.error('Failed to check project lock status:', lockCheckResult.errorCode);
-          setIsLoading(false);
-          return;
-        }
-
-        const { isLocked: projectIsLocked } = lockCheckResult.data as { isLocked: boolean };
-
-        if (projectIsLocked) {
-          // Project is already locked, show popup
-          setIsLocked(true);
-          setShowLockedPopup(true);
-          setIsLoading(false);
-          return;
-        }
-
-        // Project is not locked, try to lock it
-        const lockResult = await lockProject(projectName.toLowerCase());
-
-        if (!lockResult.success) {
-          if (lockResult.errorCode === 'project-already-locked') {
-            // Another user locked it between our check and lock attempt
-            setIsLocked(true);
-            setShowLockedPopup(true);
-          } else {
-            console.error('Failed to lock project:', lockResult.errorCode);
-          }
-        } else {
-          // Successfully locked the project
-          setIsLocked(false);
-          if (onUnlock) {
-            onUnlock();
-          }
-        }
-      } catch (error) {
-        console.error('Error in project locking logic:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    checkAndLockProject();
-
-    // Cleanup function to unlock project when component unmounts
     return () => {
-      if (projectName && !isLocked) {
-        unlockProject(projectName.toLowerCase()).catch(error => {
-          console.error('Failed to unlock project on cleanup:', error);
+      doUnlock();
+    };
+  }, [projectId, formId, userId, attemptLock, doUnlock]);
+
+  // refresh lockedAt every 15s so other clients know the lock is still alive
+  useEffect(() => {
+    if (!projectId || !formId || !userId) return;
+
+    const interval = setInterval(() => {
+      if (didLockRef.current) {
+        refreshFormLock(projectId, formId, userId).catch(error => {
+          console.error('Failed to refresh form lock heartbeat:', error);
         });
       }
-    };
-  }, [projectName, onUnlock]);
+    }, HEARTBEAT_INTERVAL_MS);
 
-  // Handle locked actions (field changes, navigation, etc.)
+    return () => clearInterval(interval);
+  }, [projectId, formId, userId]);
+
+  // when the lock document changes, re-attempt if lock was released or went stale
+  useEffect(() => {
+    if (!projectId || !formId) return;
+
+    const lockDocRef = doc(db, 'form-locks', `${projectId}_${formId}`);
+
+    const unsubscribe = onSnapshot(lockDocRef, (snapshot) => {
+      const data = snapshot.data();
+
+      // if the lock was released and we don't hold it, try to acquire it
+      if ((!data || !data.isLocked) && !didLockRef.current) {
+        attemptLock();
+      }
+    });
+
+    return () => unsubscribe();
+  }, [projectId, formId, attemptLock]);
+
+  // safety - unlock on tab/browser close (best-effort)
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      doUnlock();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [doUnlock]);
+
   const handleLockedAction = () => {
     if (isLocked) {
       setShowLockedPopup(true);
@@ -102,19 +126,12 @@ const FormLock = ({ projectName, onLockedAction, onUnlock }: FormLockProps) => {
     }
   };
 
-  // Close popup
   const closePopup = () => {
     setShowLockedPopup(false);
   };
 
-  // Handle back to project navigation
   const handleBackToProject = () => {
-    if (projectName) {
-      navigate(`/dashboard/admin/projects/${projectName}`);
-    } else {
-      // Fallback if no projectId is provided
-      navigate('/dashboard/admin/projects');
-    }
+    window.close();
   };
 
   return {
@@ -123,6 +140,7 @@ const FormLock = ({ projectName, onLockedAction, onUnlock }: FormLockProps) => {
     closePopup,
     isLocked,
     isLoading,
+    doUnlock,
     LockedPopup: showLockedPopup ? (
       <div style={{
         position: 'fixed',
@@ -145,7 +163,6 @@ const FormLock = ({ projectName, onLockedAction, onUnlock }: FormLockProps) => {
           boxShadow: '0 4px 20px rgba(0, 0, 0, 0.3)',
           position: 'relative'
         }}>
-          {/* Close button */}
           <button
             onClick={closePopup}
             style={{

--- a/frontend/src/types/Project.ts
+++ b/frontend/src/types/Project.ts
@@ -30,6 +30,8 @@ export interface Project {
     isActive: boolean;
     isPinned: boolean;
     isLocked: boolean;
+    lockedBy?: string;
+    lockedAt?: string;
     proposalFormID: string;
     riskFormID: string;
     winrockEmail: string;


### PR DESCRIPTION
- Per-form locking: Replaced project-level isLocked boolean with a dedicated form-locks Firestore collection keyed by {projectId}_{formId}. Proposal and risk forms lock independently.
- Fixed error swallowing: "form-already-locked" error was being caught as "unknown" because handleFirebaseError only recognizes FirebaseError instances. Now caught explicitly.                                                                                                 
- Fixed race condition: Removed separate checkProjectLock call. Lock is now checked and acquired in a single atomic Firestore transaction.
- Fixed refresh false-lock: Lock now stores lockedBy (user ID). Same user re-acquires their own lock on refresh instead of locking themselves out.
- Stale lock recovery: Lock holder refreshes lockedAt every 15s. Locks older than 30s are considered stale and can be taken over. This handles tab crashes where async cleanup never completes.                                                                                                  
- Real-time unlock detection: onSnapshot listener on the lock document auto-detects when a lock is released, so blocked users don't need to manually refresh.                                                                                   
                                                                                                                                                            
Btw, new firestore collection: form-locks
- documents keyed {projectId}_{formId} with { isLocked, lockedBy, lockedAt, projectId, formId }. Created automatically on first lock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form-level locking with real-time status and a locked popup when someone else is editing.
  * Automatic lock heartbeat while you edit and best-effort unlock on save or when closing the tab/window.
* **Behavior Changes**
  * Forms become read-only when locked; initial UI waits for lock state before rendering.
  * Stale locks can be taken over after ~30s of inactivity.
* **Chores**
  * Back-end rules added to secure form-lock reads/writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->